### PR TITLE
Adding uprotocol-ulink-zenoh-python Project

### DIFF
--- a/otterdog/eclipse-uprotocol.jsonnet
+++ b/otterdog/eclipse-uprotocol.jsonnet
@@ -132,5 +132,11 @@ orgs.newOrg('eclipse-uprotocol') {
       secret_scanning_push_protection: "disabled",
       web_commit_signoff_required: false,
     },
+    orgs.newRepo('uprotocol-ulink-zenoh-python') {
+      allow_update_branch: false,
+      description: "Python uLink implementation for the Zenoh transport",
+      secret_scanning_push_protection: "disabled",
+      web_commit_signoff_required: false,
+    },
   ],
 }

--- a/otterdog/eclipse-uprotocol.jsonnet
+++ b/otterdog/eclipse-uprotocol.jsonnet
@@ -129,13 +129,11 @@ orgs.newOrg('eclipse-uprotocol') {
     orgs.newRepo('uprotocol-tools') {
       allow_update_branch: false,
       description: "Collection of tools used by various other projects",
-      secret_scanning_push_protection: "disabled",
       web_commit_signoff_required: false,
     },
     orgs.newRepo('uprotocol-ulink-zenoh-python') {
       allow_update_branch: false,
       description: "Python uLink implementation for the Zenoh transport",
-      secret_scanning_push_protection: "disabled",
       web_commit_signoff_required: false,
     },
   ],

--- a/otterdog/eclipse-uprotocol.jsonnet
+++ b/otterdog/eclipse-uprotocol.jsonnet
@@ -126,5 +126,11 @@ orgs.newOrg('eclipse-uprotocol') {
       description: "Collection of tools used by various other projects",
       web_commit_signoff_required: false,
     },
+    orgs.newRepo('uprotocol-tools') {
+      allow_update_branch: false,
+      description: "Collection of tools used by various other projects",
+      secret_scanning_push_protection: "disabled",
+      web_commit_signoff_required: false,
+    },
   ],
 }


### PR DESCRIPTION
Project will be used for implementing the uLink library for the Zenoh transport written in python