### PR TITLE
Allow 1st class developers to push directly

### DIFF
--- a/otterdog/eclipse-uprotocol.jsonnet
+++ b/otterdog/eclipse-uprotocol.jsonnet
@@ -49,6 +49,7 @@ orgs.newOrg('eclipse-uprotocol') {
         orgs.newBranchProtectionRule('main') {
           required_status_checks+: ["verify-pr"],
           required_approving_review_count: 1,
+          allows_force_pushes: true,
         }
       ],
       workflows+: {


### PR DESCRIPTION
This is done to allow automation. to run for updating pom.xml on version changes.