### PR TITLE
Add api token

### DIFF
--- a/otterdog/eclipse-uprotocol.jsonnet
+++ b/otterdog/eclipse-uprotocol.jsonnet
@@ -16,6 +16,9 @@ orgs.newOrg('eclipse-uprotocol') {
     },
   },
   secrets+: [
+    orgs.newOrgSecret('BOT_GITHUB_TOKEN') {
+      value: "pass:bots/automotive.uprotocol/github.com/api-token",
+    },
     orgs.newOrgSecret('ORG_GPG_PASSPHRASE') {
       value: "pass:bots/automotive.uprotocol/gpg/passphrase",
     },


### PR DESCRIPTION
This PR adds an organization secret containing a bot token to be able to push to the repo bypassing branch protection rules. This bot can be used in a release workflow.

Example where this is used, e.g. eclipse-xpanse project:

https://github.com/eclipse-xpanse/policy-man/blob/main/.github/workflows/release.yml