### PR TITLE
Rename uprotocol-sdk-python to uprotocol-python

### DIFF
--- a/otterdog/eclipse-uprotocol.jsonnet
+++ b/otterdog/eclipse-uprotocol.jsonnet
@@ -107,6 +107,7 @@ orgs.newOrg('eclipse-uprotocol') {
       },
     },
     orgs.newRepo('uprotocol-python') {
+      aliases: ["uprotocol-sdk-python"],
       allow_merge_commit: true,
       allow_update_branch: false,
       delete_branch_on_merge: false,

--- a/otterdog/eclipse-uprotocol.jsonnet
+++ b/otterdog/eclipse-uprotocol.jsonnet
@@ -106,11 +106,11 @@ orgs.newOrg('eclipse-uprotocol') {
         actions_can_approve_pull_request_reviews: false,
       },
     },
-    orgs.newRepo('uprotocol-sdk-python') {
+    orgs.newRepo('uprotocol-python') {
       allow_merge_commit: true,
       allow_update_branch: false,
       delete_branch_on_merge: false,
-      description: "uProtocol Python SDK",
+      description: "uProtocol Language Specific Library for Python",
       web_commit_signoff_required: false,
       workflows+: {
         actions_can_approve_pull_request_reviews: false,


### PR DESCRIPTION
The term SDK in the library name was leading to a lot of unnecessary confusion.
Please refer to #14 