### PR TITLE
uprotocol-java branch protection

### DIFF
--- a/otterdog/eclipse-uprotocol.jsonnet
+++ b/otterdog/eclipse-uprotocol.jsonnet
@@ -104,6 +104,12 @@ orgs.newOrg('eclipse-uprotocol') {
       delete_branch_on_merge: false,
       description: "uProtocol Language Specific Library for Java",
       web_commit_signoff_required: false,
+      branch_protection_rules: [
+        orgs.newBranchProtectionRule('main') {
+          required_status_checks+: ["verify-pr"],
+          required_approving_review_count: 1,
+        }
+      ],
       workflows+: {
         actions_can_approve_pull_request_reviews: false,
       },


### PR DESCRIPTION
add branch protection for uprotocol-java.
requiring minimum of 1 reviewer and a successful build