### PR TITLE
Update eclipse-uprotocol.jsonnet

### DIFF
--- a/otterdog/eclipse-uprotocol.jsonnet
+++ b/otterdog/eclipse-uprotocol.jsonnet
@@ -16,6 +16,9 @@ orgs.newOrg('eclipse-uprotocol') {
     },
   },
   secrets+: [
+    orgs.newOrgSecret('CRATES_IO_TOKEN') {
+      value: "pass:bots/automotive.uprotocol/crates.io/api-token",
+    },
     orgs.newOrgSecret('BOT_GITHUB_TOKEN') {
       value: "pass:bots/automotive.uprotocol/github.com/api-token",
     },


### PR DESCRIPTION
Assistance to Release eclipse-uprotocol/uprotocol-core-api to crates.io, pypi.org, and conan.io

https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/3987