### PR TITLE
Need to turn off required_approving_review_count for zenoh-cpp

### DIFF
--- a/otterdog/eclipse-uprotocol.jsonnet
+++ b/otterdog/eclipse-uprotocol.jsonnet
@@ -282,7 +282,7 @@ orgs.newOrg('eclipse-uprotocol') {
       },
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
-          required_approving_review_count: 1,
+          required_approving_review_count: 0,
           required_status_checks+: [
             "build"
           ],


### PR DESCRIPTION
I was too fast to turn this on as I cannot approve my own merges anymore. I need to merge a change till I onboard more c++ committers.