### PR TITLE
Add project-leads to security managers

### DIFF
--- a/otterdog/eclipse-uprotocol.jsonnet
+++ b/otterdog/eclipse-uprotocol.jsonnet
@@ -6,6 +6,9 @@ orgs.newOrg('eclipse-uprotocol') {
     description: "",
     name: "Eclipse uProtocol",
     readers_can_create_discussions: true,
+    security_managers+: [
+      automotive-uprotocol-project-leads
+    ],
     two_factor_requirement: false,
     web_commit_signoff_required: false,
     workflows+: {

--- a/otterdog/eclipse-uprotocol.jsonnet
+++ b/otterdog/eclipse-uprotocol.jsonnet
@@ -7,7 +7,7 @@ orgs.newOrg('eclipse-uprotocol') {
     name: "Eclipse uProtocol",
     readers_can_create_discussions: true,
     security_managers+: [
-      automotive-uprotocol-project-leads
+      "automotive-uprotocol-project-leads",
     ],
     two_factor_requirement: false,
     web_commit_signoff_required: false,


### PR DESCRIPTION
This PR adds the project-leads to the list of security managers.

That allows you to access the security tab of the organization / projects.

We can also add all committers to the list of security managers, I just wanna get the discussion started.