### PR TITLE
Temporarily disable up-rust branch protection rules

### DIFF
--- a/otterdog/eclipse-uprotocol.jsonnet
+++ b/otterdog/eclipse-uprotocol.jsonnet
@@ -378,14 +378,6 @@ orgs.newOrg('eclipse-uprotocol') {
       allow_update_branch: false,
       delete_branch_on_merge: false,
       description: "uProtocol Specifications",
-      branch_protection_rules: [
-        orgs.newBranchProtectionRule('main') {
-          required_approving_review_count: 1,
-          required_status_checks+: [
-            "build"
-          ],
-        },
-      ],
       topics+: [
         "core",
         "uprotocol"

--- a/otterdog/eclipse-uprotocol.jsonnet
+++ b/otterdog/eclipse-uprotocol.jsonnet
@@ -351,11 +351,6 @@ orgs.newOrg('eclipse-uprotocol') {
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
           required_approving_review_count: 0,
-          required_status_checks+: [
-            "Build documentation",
-            "Lint",
-            "Test"
-          ],
         },
       ],
     },
@@ -383,6 +378,14 @@ orgs.newOrg('eclipse-uprotocol') {
       allow_update_branch: false,
       delete_branch_on_merge: false,
       description: "uProtocol Specifications",
+      branch_protection_rules: [
+        orgs.newBranchProtectionRule('main') {
+          required_approving_review_count: 1,
+          required_status_checks+: [
+            "build"
+          ],
+        },
+      ],
       topics+: [
         "core",
         "uprotocol"


### PR DESCRIPTION
We are changing the workflows in up-rust and in order to merge the change we need to temporarily disable the branch protection rules