### PR TITLE
Archive the up-core-api branch

### DIFF
--- a/otterdog/eclipse-uprotocol.jsonnet
+++ b/otterdog/eclipse-uprotocol.jsonnet
@@ -245,7 +245,7 @@ orgs.newOrg('eclipse-uprotocol') {
       allow_merge_commit: true,
       allow_update_branch: false,
       delete_branch_on_merge: false,
-      lock_branch: true,
+      archived: true,
       description: "DEPRECATED: uProtocol Core APIs and Data Model",
       topics+: [
         "core",

--- a/otterdog/eclipse-uprotocol.jsonnet
+++ b/otterdog/eclipse-uprotocol.jsonnet
@@ -245,7 +245,8 @@ orgs.newOrg('eclipse-uprotocol') {
       allow_merge_commit: true,
       allow_update_branch: false,
       delete_branch_on_merge: false,
-      description: "uProtocol Core APIs and Data Model",
+      lock_branch: true,
+      description: "DEPRECATED: uProtocol Core APIs and Data Model",
       topics+: [
         "core",
         "protos",


### PR DESCRIPTION
We have merged up-core-api into up-spec, this change will lock the repo so that it cannot be used/merged anymore.