### PR TITLE
Fix branch protection issue with up-spec project

### DIFF
--- a/otterdog/eclipse-uprotocol.jsonnet
+++ b/otterdog/eclipse-uprotocol.jsonnet
@@ -394,10 +394,7 @@ orgs.newOrg('eclipse-uprotocol') {
       web_commit_signoff_required: false,
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
-          required_approving_review_count: 1,
-          required_status_checks+: [
-            "verify-pr"
-          ],
+          required_approving_review_count: 1
         },
       ],
     },


### PR DESCRIPTION
The requirement to run the verify-pr is causing issues with other parts of the spec being able to be merged