### PR TITLE
Allow the creation of teams within eclipse-uprotocol

### DIFF
--- a/otterdog/eclipse-uprotocol.jsonnet
+++ b/otterdog/eclipse-uprotocol.jsonnet
@@ -6,6 +6,7 @@ orgs.newOrg('eclipse-uprotocol') {
     description: "Project to enable connecting automotive applications and services anywhere",
     name: "Eclipse uProtocol",
     web_commit_signoff_required: false,
+    members_can_create_teams: true,
     workflows+: {
       actions_can_approve_pull_request_reviews: false,
     },


### PR DESCRIPTION
Teams in github can be used to organize projects more effectively. Contributors can invited to a team that is assigned to a repo or project which then allows for issues to be assigned to them without first requiring them to comment. They can also be granted permission to update their tasks in project boards.

For example, a `up-cpp-contributors` group could be created such that:

1. Contributors actively working on up-cpp and related C++ projects can be assigned to issues.
2. These contributors could update the status of their tasks on the 1.5.8 C++ project board (https://github.com/orgs/eclipse-uprotocol/projects/5/views/1)

These teams *would not* grant any additional permissions, and contributors can leave the group at any time.

Without the ability to create teams, contributors who are not members of the eclipse-uprotocol organization cannot be directly assigned to tasks, cannot voluntarily take tasks (they must comment and then be assigned by a member of the organization), and cannot participate in project management boards.