### PR TITLE
Fix code scanning for C++ repos

### DIFF
--- a/otterdog/eclipse-uprotocol.jsonnet
+++ b/otterdog/eclipse-uprotocol.jsonnet
@@ -156,8 +156,8 @@ orgs.newOrg('eclipse-uprotocol') {
     orgs.newRepo('up-cpp') {
       allow_merge_commit: true,
       allow_update_branch: false,
-      code_scanning_default_languages+: [
-        "python"
+      code_scanning_default_languages: [
+        "c-cpp"
       ],
       code_scanning_default_setup_enabled: true,
       delete_branch_on_merge: false,
@@ -398,6 +398,10 @@ orgs.newOrg('eclipse-uprotocol') {
     },
     orgs.newRepo('up-transport-vsomeip-cpp') {
       allow_update_branch: false,
+      code_scanning_default_languages: [
+        "c-cpp"
+      ],
+      code_scanning_default_setup_enabled: true,
       description: "C++ uPClient for vsomeip (SOME/IP)",
       topics+: [
         "cpp",
@@ -431,6 +435,9 @@ orgs.newOrg('eclipse-uprotocol') {
     },
     orgs.newRepo('up-transport-zenoh-cpp') {
       allow_update_branch: false,
+      code_scanning_default_languages: [
+        "c-cpp"
+      ],
       code_scanning_default_setup_enabled: true,
       description: "C++ client library to connect to the zenoh implementation of uProtocol",
       topics+: [
@@ -488,6 +495,10 @@ orgs.newOrg('eclipse-uprotocol') {
     },
     orgs.newRepo('up-zenoh-example-cpp') {
       allow_update_branch: false,
+      code_scanning_default_languages: [
+        "c-cpp"
+      ],
+      code_scanning_default_setup_enabled: true,
       description: "C++ Example application and service that utilizes up-transport-zenoh-cpp",
       topics+: [
         "cpp",


### PR DESCRIPTION
C++ repos were misconfigured for python scanning. This results in scan failures since the C++ repos do not contain python code.

Example failures:

- https://github.com/eclipse-uprotocol/up-transport-zenoh-cpp/actions/runs/9277126723/job/25525668595
- https://github.com/eclipse-uprotocol/up-cpp/actions/runs/9523660282/job/26255403044