### PR TITLE
Up-transport-socket

### DIFF
--- a/otterdog/eclipse-uprotocol.jsonnet
+++ b/otterdog/eclipse-uprotocol.jsonnet
@@ -545,5 +545,20 @@ orgs.newOrg('eclipse-uprotocol') {
       ],
       web_commit_signoff_required: false,
     },
+    orgs.newRepo('up-transport-socket') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      description: "Simple socket implementations of uTransport written in C++, Rust, Python, and Java to test uE-2-uE communication",
+      topics+: [
+        "cpp",
+        "python",
+        "java",
+        "rust",
+        "up-transport",
+        "uprotocol",
+        "socket"
+      ],
+      web_commit_signoff_required: false,
+    },
   ],
 }

--- a/otterdog/eclipse-uprotocol.jsonnet
+++ b/otterdog/eclipse-uprotocol.jsonnet
@@ -240,7 +240,7 @@ orgs.newOrg('eclipse-uprotocol') {
         orgs.newBranchProtectionRule('main') {
           required_approving_review_count: 1,
           required_status_checks+: [
-            "test-and-coverage",
+            "Test with coverage",
             "lint"
           ],
         },

--- a/otterdog/eclipse-uprotocol.jsonnet
+++ b/otterdog/eclipse-uprotocol.jsonnet
@@ -194,7 +194,8 @@ orgs.newOrg('eclipse-uprotocol') {
         orgs.newBranchProtectionRule('main') {
           required_approving_review_count: 1,
           required_status_checks+: [
-            "verify-pr"
+            "verify-pr",
+            "lint"
           ],
         },
       ],
@@ -235,6 +236,15 @@ orgs.newOrg('eclipse-uprotocol') {
         "core",
         "python",
         "uprotocol"
+      ],
+      branch_protection_rules: [
+        orgs.newBranchProtectionRule('main') {
+          required_approving_review_count: 1,
+          required_status_checks+: [
+            "test-and-coverage",
+            "lint"
+          ],
+        },
       ],
       web_commit_signoff_required: false,
     },


### PR DESCRIPTION
Pulling out the socket transport from up-tck so we can use it for other purposes. This project will house all implementations of the socket transport (including the required message dispatcher written in python).