### PR TITLE
Enabling merge commits in TCK

### DIFF
--- a/otterdog/eclipse-uprotocol.jsonnet
+++ b/otterdog/eclipse-uprotocol.jsonnet
@@ -319,6 +319,7 @@ orgs.newOrg('eclipse-uprotocol') {
     },
     orgs.newRepo('up-tck') {
       allow_update_branch: false,
+      allow_merge_commit: true,
       code_scanning_default_languages+: [
         "python"
       ],


### PR DESCRIPTION
Merge commits allow for well-crafted PRs to be preserved with full attribution to the contributor and the history intact, should the commiter decide it is necessary. They also provide clearer traceability to originating pull request - the final set of commits in the PR are exactly what gets merged into the target branch.

Without merge commits, the other two options provided by GitHub have drawbacks. Squash and merge does not allow for histories to be preserved with complex features. Some changes may be easier to understand as a series of commits; for example, one of our spec alignment bugfixes in up-cpp:

    https://github.com/eclipse-uprotocol/up-cpp/pull/240/commits

Squash and merge can also lose clear authorship when the commits are squashed. Not only are the commits by the true author replaced by a squash commit generated by the committer, but any PR containing commits by more than one author will result in a final commit with one listed author and vague attribution in the commit message to the rest of the authors.

Rebase and merge brings new problems. While it does preserve the history and authorship, it makes traceability to the original PR more difficult since the final commits were not present in the PR and there is no merge commit generated referencing the PR. Additionally, since the sequence of commits is altered, the committer will be added to the attribution of the history for *each* commit instead of just the merge commit and any additional author metadata (beyond the author field, such as gpg signatures) will be lost.