### PR TITLE
Add repository variable for OFT file patterns

### DIFF
--- a/otterdog/eclipse-uprotocol.jsonnet
+++ b/otterdog/eclipse-uprotocol.jsonnet
@@ -271,6 +271,11 @@ orgs.newOrg('eclipse-uprotocol') {
         "rust",
         "uprotocol"
       ],
+      variables+: [
+        orgs.newRepoVariable('UP_SPEC_OPEN_FAST_TRACE_FILE_PATTERNS') {
+          value: "*.{adoc,md} *.rs .github examples src tests tools up-spec/*.{adoc,md} up-spec/basics up-spec/up-l2/api.adoc",
+        },
+      ],
       web_commit_signoff_required: false,
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {


### PR DESCRIPTION
The variable contains glob patterns matching the files that need to
be considered by OpenFastTrace when verifying coverage of the
requirements defined by the uProtocol specification.