### PR TITLE
Add repository for uProtocol landing page

### DIFF
--- a/otterdog/eclipse-uprotocol.jsonnet
+++ b/otterdog/eclipse-uprotocol.jsonnet
@@ -40,6 +40,28 @@ orgs.newOrg('eclipse-uprotocol') {
       delete_branch_on_merge: false,
       web_commit_signoff_required: false,
     },
+    orgs.newRepo('eclipse-uprotocol.github.io') {
+      description: "The landing page website for the uProtocol project",
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      code_scanning_default_setup_enabled: true,
+      delete_branch_on_merge: false,
+      environments: [
+        orgs.newEnvironment('github-pages') {
+          branch_policies+: [
+            "main"
+          ],
+          deployment_branch_policy: "selected",
+        },
+      ],
+      gh_pages_build_type: "workflow",
+      has_discussions: false,
+      topics+: [
+        "landing-page",
+        "uprotocol"
+      ],
+      web_commit_signoff_required: false,
+    },
     orgs.newRepo('manifests') {
       allow_update_branch: false,
       code_scanning_default_setup_enabled: true,


### PR DESCRIPTION
Deliberately chose the repository name to comply with
requirements for being able to publish on GitHub Pages.
See https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages#types-of-github-pages-sites