### PR TITLE
Fix file patterns used for OFT in up-rust

### DIFF
--- a/otterdog/eclipse-uprotocol.jsonnet
+++ b/otterdog/eclipse-uprotocol.jsonnet
@@ -273,7 +273,7 @@ orgs.newOrg('eclipse-uprotocol') {
       ],
       variables+: [
         orgs.newRepoVariable('UP_SPEC_OPEN_FAST_TRACE_FILE_PATTERNS') {
-          value: "*.{adoc,md} *.rs .github examples src tests tools up-spec/*.{adoc,md} up-spec/basics up-spec/up-l2/api.adoc",
+          value: "*.adoc *.md *.rs .github examples src tests tools up-spec/*.adoc up-spec/*.md up-spec/basics up-spec/up-l2/api.adoc",
         },
       ],
       web_commit_signoff_required: false,


### PR DESCRIPTION
bash does not support expanding braces as expected.