### PR TITLE
Add repo variable for implementation file patterns

### DIFF
--- a/otterdog/eclipse-uprotocol.jsonnet
+++ b/otterdog/eclipse-uprotocol.jsonnet
@@ -297,6 +297,9 @@ orgs.newOrg('eclipse-uprotocol') {
         orgs.newRepoVariable('UP_SPEC_OPEN_FAST_TRACE_FILE_PATTERNS') {
           value: "*.adoc *.md *.rs .github examples src tests tools up-spec/*.adoc up-spec/*.md up-spec/basics up-spec/up-l2/api.adoc",
         },
+        orgs.newRepoVariable('UP_RUST_OPEN_FAST_TRACE_FILE_PATTERNS') {
+          value: "*.adoc *.md *.rs .github examples src tests tools",
+        },
       ],
       web_commit_signoff_required: false,
       branch_protection_rules: [


### PR DESCRIPTION
Added a separate repository variable for up-rust, which contains
file patterns specifying the implementation artitifacts for the
OpenFastTrace check.

Having these patterns in a separate variable allows the same patterns
to be used for creating an archive with all the relevant specification
documents.

In a second setp, the up-rust CI workflows will be adapted to make use of both variables and then, in a third step, the patterns will be removed from the UP_SPEC_OPEN_FAST_TRACE_FILE_PATTERNS variable.