### PR TITLE
Remove up-rust patterns from up-spec patterns variable

### DIFF
--- a/otterdog/eclipse-uprotocol.jsonnet
+++ b/otterdog/eclipse-uprotocol.jsonnet
@@ -295,7 +295,7 @@ orgs.newOrg('eclipse-uprotocol') {
       ],
       variables+: [
         orgs.newRepoVariable('UP_SPEC_OPEN_FAST_TRACE_FILE_PATTERNS') {
-          value: "*.adoc *.md *.rs .github examples src tests tools up-spec/*.adoc up-spec/*.md up-spec/basics up-spec/up-l2/api.adoc",
+          value: "up-spec/*.adoc up-spec/*.md up-spec/basics up-spec/up-l2/api.adoc",
         },
         orgs.newRepoVariable('UP_RUST_OPEN_FAST_TRACE_FILE_PATTERNS') {
           value: "*.adoc *.md *.rs .github examples src tests tools",


### PR DESCRIPTION
The UP_SPEC_OPEN_FAST_TRACE_FILE_PATTERNS variable has been changed
to only contain patterns for the uProtocol Spec files that contain
requirements that are relevant for up-rust.