### PR TITLE
Use common variable name for artifacts to include in OFT check

### DIFF
--- a/otterdog/eclipse-uprotocol.jsonnet
+++ b/otterdog/eclipse-uprotocol.jsonnet
@@ -328,11 +328,11 @@ orgs.newOrg('automotive.uprotocol', 'eclipse-uprotocol') {
       ],
       web_commit_signoff_required: false,
       variables: [
-        orgs.newRepoVariable('UP_RUST_OPEN_FAST_TRACE_FILE_PATTERNS') {
+        orgs.newRepoVariable('UP_COMPONENT_OPEN_FAST_TRACE_FILE_PATTERNS') {
           value: "*.adoc *.md *.rs .github examples src tests tools",
         },
         orgs.newRepoVariable('UP_SPEC_OPEN_FAST_TRACE_FILE_PATTERNS') {
-          value: "up-spec/*.adoc up-spec/*.md up-spec/basics up-spec/up-l1/cloudevents.adoc up-spec/up-l2/api.adoc",
+          value: "up-spec/*.adoc up-spec/*.md up-spec/basics up-spec/up-l1/README.adoc up-spec/up-l1/cloudevents.adoc up-spec/up-l2/api.adoc",
         },
       ],
       branch_protection_rules: [
@@ -494,9 +494,9 @@ orgs.newOrg('automotive.uprotocol', 'eclipse-uprotocol') {
       web_commit_signoff_required: false,
       variables: [
         orgs.newRepoVariable('UP_SPEC_OPEN_FAST_TRACE_FILE_PATTERNS') {
-          value: "up-spec/up-l1/mqtt_5.adoc",
+          value: "up-spec/basics/uattributes.adoc up-spec/up-l1/README.adoc up-spec/up-l1/mqtt_5.adoc",
         },
-        orgs.newRepoVariable('UP_TRANSPORT_MQTT5_OPEN_FAST_TRACE_FILE_PATTERNS') {
+        orgs.newRepoVariable('UP_COMPONENT_OPEN_FAST_TRACE_FILE_PATTERNS') {
           value: "*.adoc *.md *.rs .github examples src tests",
         },
       ],
@@ -618,7 +618,7 @@ orgs.newOrg('automotive.uprotocol', 'eclipse-uprotocol') {
           value: "Cargo.toml *.md .github examples src tests",
         },
         orgs.newRepoVariable('UP_SPEC_OPEN_FAST_TRACE_FILE_PATTERNS') {
-          value: "up-spec/up-l1/zenoh.adoc",
+          value: "up-spec/basics/uattributes.adoc up-spec/up-l1/README.adoc up-spec/up-l1/zenoh.adoc",
         },
       ],
       web_commit_signoff_required: false,


### PR DESCRIPTION
So far, each component had been using a var with a component specific
name. However, this is not necessary and required maintaining
component specific workflows for tracing requirements.

Also added relevabt up-spec artifacts that had recently been amended
with OFT specitems.